### PR TITLE
Add multi-image support via images_json input

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Updates kustomize overlays with new image tags, labels, and annotations.
 | `debug` | Enable debug output | ❌ | `false` |
 | `image` | Image name (without tag) | ❌ | - |
 | `tag` | Image tag | ❌ | - |
+| `images_json` | Multiple images as JSON array (see examples below) | ❌ | - |
 | `version_label` | Value for app.kubernetes.io/version label | ❌ | - |
 | `annotations` | Annotations to add (key:value or key=value format, one per line) | ❌ | - |
 | `labels` | Labels to add (key:value or key=value format, one per line) | ❌ | - |
@@ -125,7 +126,21 @@ This patches environment files (like `container.env` or `.env`) that are used by
       }
 ```
 
-### Update multiple images
+### Update multiple images (Recommended)
+```yaml
+- name: Update multiple images
+  uses: KoalaOps/kustomize-edit@v1
+  with:
+    overlay_dir: deploy/overlays/production
+    images_json: |
+      [
+        {"name": "registry.io/myapp", "newTag": "v1.2.3"},
+        {"name": "registry.io/myapp-migrator", "newTag": "v1.2.3"},
+        {"name": "registry.io/sidecar", "newTag": "v2.0.0"}
+      ]
+```
+
+### Update multiple images (Alternative - multiple calls)
 ```yaml
 - name: Update API image
   uses: KoalaOps/kustomize-edit@v1
@@ -151,6 +166,52 @@ This patches environment files (like `container.env` or `.env`) that are used by
     image: app
     tag: feature-${{ github.event.number }}
     namespace: pr-${{ github.event.number }}
+```
+
+## Multiple Images Support
+
+The `images_json` input allows you to update multiple container images in a single action call. This is particularly useful for:
+
+- **Main + auxiliary images** (e.g., app + migrator, app + sidecar)
+- **Microservices with multiple containers** in the same deployment
+- **Services with init containers** that need version pinning
+
+### Format
+
+The `images_json` input expects a JSON array matching [Kustomize's native image format](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/images/):
+
+```json
+[
+  {
+    "name": "registry.io/app",
+    "newTag": "v1.2.3"
+  },
+  {
+    "name": "registry.io/app-migrator",
+    "newTag": "v1.2.3"
+  }
+]
+```
+
+**Required fields:**
+- `name` - Full image name/repository (e.g., `gcr.io/project/image` or `myapp`)
+- `newTag` - New tag to set (e.g., `v1.2.3`, `latest`, `main-abc123`)
+
+**Mutual Exclusivity:**
+Provide either `images_json` OR `image`+`tag`, not both. The action will error if both are provided.
+
+### Example: Service with database migrator
+
+```yaml
+- name: Update app and migrator images
+  uses: KoalaOps/kustomize-edit@v1
+  with:
+    overlay_dir: deploy/overlays/production
+    images_json: |
+      [
+        {"name": "europe-docker.pkg.dev/myproject/myapp", "newTag": "${{ github.sha }}"},
+        {"name": "europe-docker.pkg.dev/myproject/myapp-migrator", "newTag": "${{ github.sha }}"}
+      ]
 ```
 
 ## How It Works

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   tag:
     description: 'Image tag'
     required: false
+  images_json:
+    description: 'Multiple images as JSON array [{"name":"registry.io/app","newTag":"v1.2.3"}]. Mutually exclusive with image/tag.'
+    required: false
   version_label:
     description: 'Value for app.kubernetes.io/version label'
     required: false
@@ -89,25 +92,78 @@ runs:
           echo "::error::Overlay directory not found: ${{ inputs.overlay_dir }}"
           exit 1
         fi
-        
+
         if [ ! -f "${{ inputs.overlay_dir }}/kustomization.yaml" ]; then
           echo "::error::No kustomization.yaml found in ${{ inputs.overlay_dir }}"
           exit 1
         fi
-        
+
         echo "✅ Found kustomization.yaml in: ${{ inputs.overlay_dir }}"
-    
-    - name: Set image and tag
-      if: inputs.image != '' && inputs.tag != ''
+
+    - name: Patch environment files
+      if: inputs.env_patches != ''
+      uses: KoalaOps/patch-env-files@v1
+      with:
+        path: ${{ inputs.overlay_dir }}
+        patches: ${{ inputs.env_patches }}
+
+    - name: Set images (single or multiple)
+      if: (inputs.image != '' && inputs.tag != '') || inputs.images_json != ''
       shell: bash
       working-directory: ${{ inputs.overlay_dir }}
       run: |
         set -euo pipefail
-        echo "🏷️ Setting image: ${{ inputs.image }}:${{ inputs.tag }}"
-        # Set the image with its tag
-        # Format: [old-image-name=]new-image-name:new-tag
-        # kustomize will match any existing image that starts with the image name
-        kustomize edit set image "${{ inputs.image }}:${{ inputs.tag }}"
+
+        # Validate mutual exclusivity
+        if [ -n "${{ inputs.images_json }}" ] && ( [ -n "${{ inputs.image }}" ] || [ -n "${{ inputs.tag }}" ] ); then
+          echo "::error::Provide either images_json OR image+tag, not both."
+          exit 1
+        fi
+
+        # Process images_json
+        if [ -n "${{ inputs.images_json }}" ]; then
+          # Validate JSON format
+          if ! echo '${{ inputs.images_json }}' | jq empty 2>/dev/null; then
+            echo "::error::Invalid images_json format. Expected JSON array like: [{\"name\":\"registry.io/app\",\"newTag\":\"v1.2.3\"}]"
+            exit 1
+          fi
+
+          # Count images
+          IMAGE_COUNT=$(echo '${{ inputs.images_json }}' | jq 'length')
+
+          # Collect image summary for logging
+          IMAGE_SUMMARY=$(echo '${{ inputs.images_json }}' | jq -r '.[] | "\(.name):\(.newTag)"' | paste -sd ', ' -)
+
+          # Iterate through images and set each one
+          echo '${{ inputs.images_json }}' | jq -c '.[]' | while read -r img; do
+            NAME=$(echo "$img" | jq -r '.name // empty')
+            NEW_TAG=$(echo "$img" | jq -r '.newTag // empty')
+
+            if [ -z "$NAME" ]; then
+              echo "::error::Image entry missing 'name' field: $img"
+              exit 1
+            fi
+
+            if [ -z "$NEW_TAG" ]; then
+              echo "::error::Image entry missing 'newTag' field: $img"
+              exit 1
+            fi
+
+            kustomize edit set image "$NAME:$NEW_TAG"
+          done
+
+          echo "✅ Set $IMAGE_COUNT image(s): $IMAGE_SUMMARY"
+
+        # Process single image
+        elif [ -n "${{ inputs.image }}" ] && [ -n "${{ inputs.tag }}" ]; then
+          kustomize edit set image "${{ inputs.image }}:${{ inputs.tag }}"
+          echo "✅ Set image: ${{ inputs.image }}:${{ inputs.tag }}"
+
+        # Error if neither provided
+        else
+          echo "::error::Either images_json OR both image and tag must be provided."
+          exit 1
+        fi
     
     - name: Set version label
       if: inputs.version_label != ''
@@ -246,14 +302,7 @@ runs:
           echo "  - $NAME: $COUNT replicas"
           kustomize edit set replicas "${NAME}=${COUNT}"
         done
-    
-    - name: Patch environment files
-      if: inputs.env_patches != ''
-      uses: KoalaOps/patch-env-files@v1
-      with:
-        path: ${{ inputs.overlay_dir }}
-        patches: ${{ inputs.env_patches }}
-    
+
     - name: Validate kustomization
       shell: bash
       working-directory: ${{ inputs.overlay_dir }}


### PR DESCRIPTION
Adds support for updating multiple container images in a single action call.

## Changes

- New `images_json` input accepting array: `[{"name":"registry/app","newTag":"v1.2.3"}]`
- **Self-contained validation**: Image input validation happens within the image-setting step (mutual exclusivity + completeness)
- **Improved operation order**: Environment patches run BEFORE image edits (clearer git diffs)
- **Summary logging**: Prints `Set N image(s): registry/app:v1.2.3, ...` for quick CI scanning
- Maintains full backwards compatibility with existing `image`/`tag` inputs
- Comprehensive documentation with examples

## Use Cases

- **Database migrations**: Deploy app + migrator image together
- **Sidecar containers**: Update multiple co-located images
- **Multi-container services**: Coordinate version updates across containers

## Example

```yaml
- uses: KoalaOps/kustomize-edit@v1
  with:
    overlay_dir: deploy/overlays/production
    images_json: |
      [
        {"name": "registry.io/app", "newTag": "v1.2.3"},
        {"name": "registry.io/app-migrator", "newTag": "v1.2.3"}
      ]
```